### PR TITLE
Assign scorebet-bot to dependabot PRs

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -25,6 +25,10 @@ const handle = async (token, reviewers, teamReviewers) => {
 const assign = async (octokit) => {
   try {
     const { owner, repo, number } = context.issue
+    const assignee = context.actor 
+    if (context.actor == 'dependabot[bot]') {
+      assignee = 'scorebet-bot'
+    }
     await octokit.issues.addAssignees({
       owner: owner,
       repo: repo,


### PR DESCRIPTION
When dependabot PRs are created, this action fails because it attempts to assign `dependabot[bot]` to the generated PRs. That's not possible since `dependabot[bot]` is an app and not an actual bot account. This PR assigns a default `scorebet-bot` to dependabot PRs, but uses the `context.actor` (i.e. PR creator) for other PRs.